### PR TITLE
Downgrande react-native-test-utils version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
 
 branches:
   only:
-- master
+    - master
 
 install:
   - yarn

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-native": "0.51.0",
     "react-native-animatable": "1.2.4",
     "react-native-elements": "0.18.5",
-    "react-native-test-utils": "^1.0.6",
+    "react-native-test-utils": "1.0.6",
     "react-navigation": "1.0.0-beta.21",
     "react-redux": "5.0.6",
     "redux": "3.7.2",


### PR DESCRIPTION
Seems like `react-native-test-utils` behaves differently between version `1.0.6` and `1.1.1`, in the first one `component.query('Something')` works fine while in the second one it doesn't.

I've opened an issue already, in the meantime let's fix the version to `1.0.6` so everything works.